### PR TITLE
Use parent namespace as targetNamespace to handle implicit

### DIFF
--- a/soapfish/templates/xsd
+++ b/soapfish/templates/xsd
@@ -1,6 +1,6 @@
 {#- XSD Imports -#}
 {%- for imp in schema.imports %}
-{{- resolve_import(imp, known_namespaces) }}
+{{- resolve_import(imp, known_namespaces, schema.targetNamespace) }}
 {%- endfor %}
 # {{ schema.targetNamespace }}{# Output the name of the schema in a comment. #}
 {# [blank line] #}

--- a/soapfish/wsdl2py.py
+++ b/soapfish/wsdl2py.py
@@ -67,7 +67,8 @@ def generate_code_from_wsdl(xml, target, use_wsa=False, encoding='utf8'):
     definitions = wsdl.Definitions.parse_xmlelement(xmlelement)
     schema = definitions.types.schema
     xsd_namespace = find_xsd_namespaces(xmlelement.nsmap)
-    schemaxml = schema_to_py(schema, xsd_namespace)
+    schemaxml = schema_to_py(schema, xsd_namespace,
+                             parent_namespace=definitions.targetNamespace)
 
     tpl = env.get_template('wsdl')
     return tpl.render(

--- a/soapfish/xsd2py.py
+++ b/soapfish/xsd2py.py
@@ -53,11 +53,11 @@ def get_rendering_environment():
     return env
 
 
-def resolve_import(xsdimport, known_namespaces):
+def resolve_import(xsdimport, known_namespaces, parent_namespace):
     logger.info('Generating code for XSD import \'%s\'...' % xsdimport.schemaLocation)
     xml = open_document(xsdimport.schemaLocation)
     xmlelement = etree.fromstring(xml)
-    return generate_code_from_xsd(xmlelement, known_namespaces, xsdimport.schemaLocation, encoding=None)
+    return generate_code_from_xsd(xmlelement, known_namespaces, xsdimport.schemaLocation, parent_namespace, encoding=None)
 
 
 def schema_name(namespace):
@@ -66,7 +66,7 @@ def schema_name(namespace):
     return hashlib.md5(namespace.encode()).hexdigest()[0:5]
 
 
-def generate_code_from_xsd(xmlelement, known_namespaces=None, location=None, encoding='utf8'):
+def generate_code_from_xsd(xmlelement, known_namespaces=None, location=None, parent_namespace=None, encoding='utf8'):
     if known_namespaces is None:
         known_namespaces = []
     xsd_namespace = find_xsd_namespaces(xmlelement.nsmap)
@@ -83,7 +83,7 @@ def generate_code_from_xsd(xmlelement, known_namespaces=None, location=None, enc
     return schema_code.encode(encoding)
 
 
-def schema_to_py(schema, xsd_namespace, known_namespaces=None, location=None):
+def schema_to_py(schema, xsd_namespace, known_namespaces=None, location=None, parent_namespace=None):
     if known_namespaces is None:
         known_namespaces = []
     known_namespaces.append(schema.targetNamespace)
@@ -94,6 +94,10 @@ def schema_to_py(schema, xsd_namespace, known_namespaces=None, location=None):
     env.globals['location'] = location
 
     tpl = env.get_template('xsd')
+
+    if schema.targetNamespace is None:
+        schema.targetNamespace = parent_namespace
+
     return tpl.render(schema=schema)
 
 

--- a/tests/xsd_code_generation_test.py
+++ b/tests/xsd_code_generation_test.py
@@ -119,6 +119,17 @@ class XSDCodeGenerationTest(PythonicTestCase):
         # Check generated XML
         # <job><person><name>Foo</name></person></job>
     
+    def test_implicit_target_namespace(self):
+        xml = ('<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" \n'
+            '    elementFormDefault="qualified">\n'
+            '    <xs:element name="field" type="xsd:string" />\n'
+            '</xs:schema>')
+        xml_element = etree.fromstring(xml)
+        generated_schema = xsdspec.Schema.parse_xmlelement(xml_element)
+        xsd2py.schema_to_py(generated_schema, ['xs'], known_namespaces=[],
+                            parent_namespace="http://site.example/ws/spec")
+
+
     def _generated_symbols(self, code_string):
         # imports not present in generated code
         from soapfish import xsd


### PR DESCRIPTION
targetNamespace values in xsd:schema.

Fix #35