### PR TITLE
Failing test cases for multiple schemas and inheritance

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,25 @@
+import logging
+
+def generated_symbols(code_string):
+    # imports not present in generated code
+    from soapfish import xsd
+    from soapfish.xsd import UNBOUNDED
+
+    new_locals = dict(locals())
+
+    try:
+        # Let's trust our own code generation...
+        exec(code_string, {}, new_locals)
+    except Exception:
+        logging.warning("Code could not be imported:\n%s", code_string)
+        raise
+    new_variables = set(new_locals).difference(locals())
+
+    schema = None
+    new_symbols = dict()
+    for name in new_variables:
+        symbol_ = new_locals[name]
+        new_symbols[name] = symbol_
+        if isinstance(symbol_, xsd.Schema):
+            schema = symbol_
+    return schema, new_symbols

--- a/tests/test_wsdl_code_generation.py
+++ b/tests/test_wsdl_code_generation.py
@@ -1,0 +1,51 @@
+from __future__ import print_function
+
+import unittest
+
+from soapfish import xsd
+from soapfish import wsdl2py
+from soapfish.lib.pythonic_testcase import *
+from tests import generated_symbols
+
+
+class XSDCodeGenerationTest(unittest.TestCase):
+    @unittest.expectedFailure
+    def test_can_generate_code_for_two_schemas(self):
+        xml = '<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:b="http://example.org/B">'\
+              '    <wsdl:types>'\
+              '        <xsd:schema elementFormDefault="qualified" targetNamespace="http://example.org/A">' \
+              '            <xsd:import namespace="http://example.org/B"/>' \
+              '            <xsd:element name="A" type="b:B"/>' \
+              '        </xsd:schema>' \
+              '        <xsd:schema elementFormDefault="qualified" targetNamespace="http://example.org/B">'\
+              '            <xsd:element name="B" type="xsd:string"/>'\
+              '        </xsd:schema>'\
+              '    </wsdl:types>'\
+              '</wsdl:definitions>'
+        code_string = wsdl2py.generate_code_from_wsdl(xml, 'client')
+
+        schema, new_symbols = generated_symbols(code_string)
+        assert_not_none(schema)
+        assert_length(4, new_symbols)
+
+        assert_equals(['B', 'A'], list(schema.elements))
+
+    @unittest.expectedFailure
+    def test_can_generate_code_for_inheritance(self):
+        xml = '<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">' \
+              '    <wsdl:types>' \
+              '        <xsd:schema elementFormDefault="qualified" targetNamespace="http://example.org/A">' \
+              '            <xsd:element name="A" type="B"/>' \
+              '            <xsd:element name="B" type="xsd:string"/>' \
+              '        </xsd:schema>' \
+              '    </wsdl:types>' \
+              '</wsdl:definitions>'
+        code_string = wsdl2py.generate_code_from_wsdl(xml, 'client')
+
+        schema, new_symbols = generated_symbols(code_string)
+        assert_not_none(schema)
+        assert_length(4, new_symbols)
+
+        assert_equals(['B', 'A'], list(schema.elements))
+        assert_isinstance(schema.elements['B']._type, xsd.String)
+        assert_isinstance(schema.elements['A']._type, schema.elements['B']._type.__class__)


### PR DESCRIPTION
When trying the wsdl2py on a rather complex .NET Soap Service, I stumbled into a few unhandled constructions. Attached a PR containing two failing test cases. I've named the file `test_X` as unittest2/nose2 cannot autodiscover the tests otherwise.