### PR TITLE
Parse xsd:include and serve xsd files

### DIFF
--- a/soapfish/templates/xsd
+++ b/soapfish/templates/xsd
@@ -1,6 +1,6 @@
 {#- XSD Includes -#}
 {%- for imp in schema.includes %}
-{{- resolve_import(imp, known_files) }}
+{{- resolve_import(imp, known_files, schema.targetNamespace, cwd) }}
 {%- endfor %}
 {#- XSD Imports -#}
 {%- for imp in schema.imports %}
@@ -267,7 +267,7 @@ Schema_{{ schema_name(schema, location) }} = xsd.Schema(
     includes=[{% for i in schema.includes %}Schema_{{ schema_name(i) }}{% if not loop.last %}, {% endif %}{% endfor %}],
     targetNamespace='{{ schema.targetNamespace }}',
     {%- if location %}
-    location='{{ location|url_template }}',{% endif %}
+    location='{{ location }}',{% endif %}
     elementFormDefault='{{ schema.elementFormDefault }}',
     simpleTypes=[{% for st in schema.simpleTypes %}{{ st.name|capitalize }}{% if not loop.last %}, {% endif %}{% endfor %}],
     attributeGroups=[{% for ag in schema.attributeGroups %}{{ ag.name|capitalize }}{% if not loop.last %}, {% endif %}{% endfor %}],

--- a/soapfish/templates/xsd
+++ b/soapfish/templates/xsd
@@ -1,8 +1,12 @@
+{#- XSD Includes -#}
+{%- for imp in schema.includes %}
+{{- resolve_import(imp, known_files) }}
+{%- endfor %}
 {#- XSD Imports -#}
 {%- for imp in schema.imports %}
 {{- resolve_import(imp, known_files, schema.targetNamespace, cwd) }}
 {%- endfor %}
-# {{ schema.targetNamespace }}{# Output the name of the schema in a comment. #}
+# {% if location %}{{ location }} - {% endif -%} {{ schema.targetNamespace }}{# Output the name of the schema in a comment. #}
 {# [blank line] #}
 {# [blank line] #}
 {#- Simple Types -#}
@@ -260,6 +264,7 @@ class {{ element.name|capitalize }}(xsd.ComplexType):
 {%- endfor %}
 Schema_{{ schema_name(schema, location) }} = xsd.Schema(
     imports=[{% for i in schema.imports %}Schema_{{ schema_name(i) }}{% if not loop.last %}, {% endif %}{% endfor %}],
+    includes=[{% for i in schema.includes %}Schema_{{ schema_name(i) }}{% if not loop.last %}, {% endif %}{% endfor %}],
     targetNamespace='{{ schema.targetNamespace }}',
     {%- if location %}
     location='{{ location|url_template }}',{% endif %}

--- a/soapfish/templates/xsd
+++ b/soapfish/templates/xsd
@@ -1,10 +1,10 @@
 {#- XSD Includes -#}
 {%- for imp in schema.includes %}
-{{- resolve_import(imp, known_files, schema.targetNamespace, cwd) }}
+{{- resolve_import(imp, known_files, schema.targetNamespace, cwd, base_path) }}
 {%- endfor %}
 {#- XSD Imports -#}
 {%- for imp in schema.imports %}
-{{- resolve_import(imp, known_files, schema.targetNamespace, cwd) }}
+{{- resolve_import(imp, known_files, schema.targetNamespace, cwd, base_path) }}
 {%- endfor %}
 # {% if location %}{{ location }} - {% endif -%} {{ schema.targetNamespace }}{# Output the name of the schema in a comment. #}
 {# [blank line] #}

--- a/soapfish/xsd.py
+++ b/soapfish/xsd.py
@@ -44,6 +44,7 @@ from copy import copy
 from decimal import Decimal as _Decimal
 from datetime import datetime
 import functools
+import itertools
 import logging
 import re
 
@@ -1145,7 +1146,7 @@ class Schema(object):
 
     def __init__(self, targetNamespace, elementFormDefault=ElementFormDefault.UNQUALIFIED,
                  simpleTypes=[], attributeGroups=[], groups=[], complexTypes=[], elements={},
-                 imports=(), location=None):
+                 imports=(), includes=(), location=None):
         '''
         :param targetNamespace: string, xsd namespace URL.
         :param elementFormDefault: unqualified/qualified. Defines if namespaces
@@ -1165,6 +1166,7 @@ class Schema(object):
         self.complexTypes = complexTypes
         self.elements = elements
         self.imports = imports
+        self.includes = includes
         self.location = location
 
         self.__init_schema(self.simpleTypes)
@@ -1197,8 +1199,8 @@ class Schema(object):
         if name in self.elements:
             return self.elements[name]
 
-        for _import in self.imports:
-            element = _import.get_element_by_name(name)
+        for i in itertools.chain(self.imports, self.includes):
+            element = i.get_element_by_name(name)
             if element is not None:
                 return element
 

--- a/soapfish/xsd2py.py
+++ b/soapfish/xsd2py.py
@@ -75,6 +75,7 @@ def schema_name(schema, location=None):
         location = location.encode()
     except UnicodeEncodeError:
         pass
+
     # we don't have any cryptographic requirements here and md5 is faster than
     # sha512 so there is no harm using an outdated algorithm.
     return hashlib.md5(location).hexdigest()[0:5]
@@ -88,8 +89,8 @@ def generate_code_from_xsd(xmlelement, known_files=None, location=None,
 
     schema = Schema.parse_xmlelement(xmlelement)
 
-    # Skip if this schema has already been included:
-    if schema.targetNamespace in known_files:
+    # Skip if this file has already been included:
+    if location and location in known_files:
         return ''
 
     schema_code = schema_to_py(schema, xsd_namespace, known_files,

--- a/soapfish/xsdspec.py
+++ b/soapfish/xsdspec.py
@@ -141,6 +141,10 @@ class Import(xsd.ComplexType):
     namespace = xsd.Attribute(xsd.String)
 
 
+class Include(xsd.ComplexType):
+    schemaLocation = xsd.Attribute(xsd.String)
+
+
 class Schema(xsd.ComplexType):
     NAMESPACE = ns.xsd
     targetNamespace = xsd.Attribute(xsd.String)
@@ -149,6 +153,7 @@ class Schema(xsd.ComplexType):
         use=xsd.Use.OPTIONAL, default='unqualified',
     )
     imports = xsd.ListElement(Import, 'import')
+    includes = xsd.ListElement(Include, 'include')
     simpleTypes = xsd.ListElement(SimpleType, 'simpleType')
     groups = xsd.ListElement(Group, 'group')
     attributeGroups = xsd.ListElement(AttributeGroup, 'attributeGroup')

--- a/tests/assets/include/include.wsdl
+++ b/tests/assets/include/include.wsdl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestRelativePaths" targetNamespace="http://example.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com">
+            <xsd:include schemaLocation="schema1.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+</wsdl:definitions>

--- a/tests/assets/include/schema1.xsd
+++ b/tests/assets/include/schema1.xsd
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://example.com" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="Schema1_Element" type="xsd:string"/>
+</xsd:schema>

--- a/tests/assets/relative/1/2/schema2.xsd
+++ b/tests/assets/relative/1/2/schema2.xsd
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema elementFormDefault="qualified" targetNamespace="http://example.com/2" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <xsd:import namespace='http://example.com/3' schemaLocation="../3/schema3.xsd"/>
+    <!-- this is the same file and must not be loaded again -->
+    <xsd:import namespace='http://example.com/3' schemaLocation="../2/../3/schema3.xsd"/>
     <xsd:element name="Schema2_Element" type="xsd:string"/>
 </xsd:schema>

--- a/tests/assets/relative/1/schema1.xsd
+++ b/tests/assets/relative/1/schema1.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema elementFormDefault="qualified" targetNamespace="http://example.com/1" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <xsd:import namespace='http://example.com/2' schemaLocation="2/schema2.xsd"/>
+    <xsd:import namespace='http://example.com/3' schemaLocation="3/schema3.xsd"/>
 </xsd:schema>

--- a/tests/code_generation_test.py
+++ b/tests/code_generation_test.py
@@ -326,6 +326,14 @@ class CodeGenerationTest(unittest.TestCase):
         assert_contains('Schema1_Element', code)
         assert_contains('Schema2_Element', code)
 
+    def test_schema_xsd_include(self):
+        path = 'tests/assets/include/include.wsdl'
+        xml = open_document(path)
+        code = generate_code_from_wsdl(xml, 'server', cwd=os.path.dirname(path))
+        if six.PY3:
+            code = code.decode()
+        assert_contains('Schema1_Element', code)
+
     def test_schema_xsd_restriction(self):
         xmlelement = etree.fromstring(XSD_RESTRICTION)
         code = generate_code_from_xsd(xmlelement)

--- a/tests/code_generation_test.py
+++ b/tests/code_generation_test.py
@@ -316,6 +316,7 @@ class CodeGenerationTest(unittest.TestCase):
             code = code.decode()
         assert_contains('Schema2_Element', code)
         assert_contains('Schema3_Element', code)
+        self.assertEqual(1, code.count('Schema3_Element'))
 
     def test_import_same_namespace(self):
         path = 'tests/assets/same_namespace/same_namespace.wsdl'


### PR DESCRIPTION
I implemented the parser to xsd:include tags and the server response to XSD requests (`?xsd=myfile.xsd`)

It is a long diff because I had to rewrite some code to use locations instead of namespaces to identify `Schema_XXX` and to avoid duplicated schema processing.

I still want to write some tests here and reorganize my commits, but I need someone to check if my changes make sense.
