### PR TITLE
Fix `SOAPVersion.get_version` and write some tests.

### DIFF
--- a/soapfish/soap.py
+++ b/soapfish/soap.py
@@ -26,10 +26,10 @@ class SOAPVersion:
 
     @classmethod
     def get_version(cls, namespace):
-        if namespace == cls.SOAP11.ENVELOPE or namespace == cls.SOAP11.BINDING:
+        if namespace == cls.SOAP11.ENVELOPE_NAMESPACE or namespace == cls.SOAP11.BINDING_NAMESPACE:
             return cls.SOAP11
-        elif  namespace == cls.SOAP12.ENVELOPE or namespace == cls.SOAP12.BINDING:
-            return cls.SOAP11
+        elif namespace == cls.SOAP12.ENVELOPE_NAMESPACE or namespace == cls.SOAP12.BINDING_NAMESPACE:
+            return cls.SOAP12
         else:
             raise ValueError("SOAP version with namespace '%s' is not supported." % namespace)
 

--- a/tests/soap_test.py
+++ b/tests/soap_test.py
@@ -143,6 +143,20 @@ class SOAPVersionTest(unittest.TestCase):
         soap_version = soap.SOAPVersion.get_version_from_xml(xml)
         assert_equals(soap.SOAPVersion.SOAP11, soap_version)
 
+    def test_get_version_soap11(self):
+        v = soap.SOAPVersion.get_version(soap11.ENVELOPE_NAMESPACE)
+        assert_equals(soap11.NAME, v.NAME)
+
+        v = soap.SOAPVersion.get_version(soap11.BINDING_NAMESPACE)
+        assert_equals(soap11.NAME, v.NAME)
+
+    def test_get_version_soap12(self):
+        v = soap.SOAPVersion.get_version(soap12.ENVELOPE_NAMESPACE)
+        assert_equals(soap12.NAME, v.NAME)
+
+        v = soap.SOAPVersion.get_version(soap12.BINDING_NAMESPACE)
+        assert_equals(soap12.NAME, v.NAME)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The comparison has invalid attributes (`ENVELOPE -> ENVELOPE_NAMESPACE`
and `BINDING -> BINDING_NAMESPACE`) and it was returning always SOAP11.