### PR TITLE
Prefer unittest self.assertRaises instead of pythonic_tests.assert_ra…

### DIFF
--- a/tests/xsd/date_test.py
+++ b/tests/xsd/date_test.py
@@ -31,7 +31,7 @@ class DateTest(SimpleTypeTestCase):
     def test_wrong_type(self):
         mixed = xsd.Element(xsd.DateTime)
         xmlelement = etree.Element('foo')
-        assert_raises(Exception, lambda: mixed.render(xmlelement, 'bar', 1))
+        self.assertRaises(Exception, mixed.render, xmlelement, 'bar', 1)
 
     def test_parsing_utctimezone(self):
         class Test(xsd.ComplexType):

--- a/tests/xsd_types/xsddate_test.py
+++ b/tests/xsd_types/xsddate_test.py
@@ -12,9 +12,9 @@ class XSDDateTest(PythonicTestCase):
         assert_equals(2012, XSDDate(2012, 2, 29).year)
 
     def test_raises_exception_when_instantiating_invalid_dates(self):
-        assert_raises(ValueError, lambda: XSDDate(2014, 2, 50))
-        assert_raises(ValueError, lambda: XSDDate(2014, 13, 10))
-        assert_raises(ValueError, lambda: XSDDate(2011, 2, 29))
+        self.assertRaises(ValueError, XSDDate, 2014, 2, 50)
+        self.assertRaises(ValueError, XSDDate, 2014, 13, 10)
+        self.assertRaises(ValueError, XSDDate, 2011, 2, 29)
 
     def test_supports_very_distant_dates(self):
         raise SkipTest('XSDDate can currently only represent the value range of datetime.date')


### PR DESCRIPTION
…ises,

to avoid a Python 2.6 bug.