### PR TITLE
Handle relative schema paths. Fix #47

### DIFF
--- a/soapfish/templates/xsd
+++ b/soapfish/templates/xsd
@@ -1,6 +1,6 @@
 {#- XSD Imports -#}
 {%- for imp in schema.imports %}
-{{- resolve_import(imp, known_namespaces, schema.targetNamespace) }}
+{{- resolve_import(imp, known_namespaces, schema.targetNamespace, cwd) }}
 {%- endfor %}
 # {{ schema.targetNamespace }}{# Output the name of the schema in a comment. #}
 {# [blank line] #}

--- a/tests/assets/relative/1/2/schema2.xsd
+++ b/tests/assets/relative/1/2/schema2.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://example.com/2" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace='http://example.com/3' schemaLocation="../3/schema3.xsd"/>
+    <xsd:element name="Schema2_Element" type="xsd:string"/>
+</xsd:schema>

--- a/tests/assets/relative/1/3/schema3.xsd
+++ b/tests/assets/relative/1/3/schema3.xsd
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://example.com/3" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="Schema3_Element" type="xsd:string"/>
+</xsd:schema>

--- a/tests/assets/relative/1/schema1.xsd
+++ b/tests/assets/relative/1/schema1.xsd
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified" targetNamespace="http://example.com/1" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace='http://example.com/2' schemaLocation="2/schema2.xsd"/>
+</xsd:schema>

--- a/tests/assets/relative/relative.wsdl
+++ b/tests/assets/relative/relative.wsdl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestRelativePaths" targetNamespace="http://example.com" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com">
+            <xsd:import namespace="http://example.com/1" schemaLocation="1/schema1.xsd"/>
+        </xsd:schema>
+    </wsdl:types>
+</wsdl:definitions>

--- a/tests/code_generation_test.py
+++ b/tests/code_generation_test.py
@@ -1,12 +1,15 @@
+import os
 import unittest
-
 import tempfile
 
 from lxml import etree
+import six
+from pythonic_testcase import *
 
 from soapfish.xsd2py import generate_code_from_xsd
 from soapfish.wsdl2py import generate_code_from_wsdl
-from soapfish import  py2wsdl
+from soapfish import py2wsdl
+from soapfish.utils import open_document
 
 
 XSD = """
@@ -277,6 +280,14 @@ class CodeGenerationTest(unittest.TestCase):
             m['PutOpsPortServiceStub'] = m.pop('PutOpsPortPortServiceStub')
         self.assertEqual(sorted(m), sorted(base))
 
+    def test_relative_paths(self):
+        path = 'tests/assets/relative/relative.wsdl'
+        xml = open_document(path)
+        code = generate_code_from_wsdl(xml, 'server', cwd=os.path.dirname(path))
+        if six.PY3:
+            code = code.decode()
+        assert_contains('Schema2_Element', code)
+        assert_contains('Schema3_Element', code)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It is a simple change, but I have to pass `cwd` to all recursive `xsd2py.schema_to_py` stack.

This change support things like:

```
# wsdl
<xsd:import namespace="http://example.com/1" schemaLocation="one/1.xsd"/>

# 1.xsd
<xsd:import namespace="http://example.com/2" schemaLocation="two/2.xsd"/>

# 2.xsd
<xsd:import namespace="http://example.com/3" schemaLocation="../three/3.xsd"/>
```
