### PR TITLE
Broken test with extension base defined after the extension.

### DIFF
--- a/soapfish/testutil/generated_symbols.py
+++ b/soapfish/testutil/generated_symbols.py
@@ -16,7 +16,7 @@ def generated_symbols(code_string):
 
     try:
         # Let's trust our own code generation...
-        exec(code_string, {}, new_locals)
+        exec(code_string, {'xsd': xsd}, new_locals)
     except Exception:
         logging.warning("Code could not be imported:\n%s", code_string)
         raise

--- a/tests/xsd_code_generation_test.py
+++ b/tests/xsd_code_generation_test.py
@@ -157,3 +157,31 @@ class XSDCodeGenerationTest(PythonicTestCase):
         my_list = new_symbols['MyList']()
         assert_equals(my_list.accept(['B']), True)
 
+    def test_can_generate_extension(self):
+        raise SkipTest('extension subclass fails with lazy defined base')
+        xml = """
+        <xs:schema targetNamespace="http://example.com"
+                    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                    elementFormDefault="qualified"
+                    attributeFormDefault="unqualified">
+            <xs:complexType name="ComplexType">
+                <xs:complexContent>
+                    <xs:extension base="Base">
+                        <xs:sequence>
+                            <xs:element maxOccurs="1" minOccurs="0"
+                                name="Field2" type="xs:string">
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:extension>
+                </xs:complexContent>
+            </xs:complexType>
+            <xs:complexType name="Base">
+                <xs:sequence>
+                    <xs:element name="Field1" type="xs:string" />
+                </xs:sequence>
+            </xs:complexType>
+        </xs:schema>
+        """
+        xml_element = etree.fromstring(xml)
+        code_string = xsd2py.generate_code_from_xsd(xml_element)
+        schema, new_symbols = generated_symbols(code_string)


### PR DESCRIPTION
```
class ComplexType(__name__ + '.Base'):
    INHERITANCE = xsd.Inheritance.EXTENSION
    INDICATOR = xsd.Sequence
    Field2 = xsd.Element(xsd.String, minOccurs=0)

    @classmethod
    def create(cls):
        instance = cls()
        return instance

class Base(xsd.ComplexType):
    INHERITANCE = None
    INDICATOR = xsd.Sequence
    Field1 = xsd.Element(xsd.String)

    @classmethod
    def create(cls, Field1):
        instance = cls()
        instance.Field1 = Field1
        return instance
```